### PR TITLE
per IRC discussion of poor parameterized type message behavior...

### DIFF
--- a/lib/MooseX/Meta/TypeConstraint/Parameterizable.pm
+++ b/lib/MooseX/Meta/TypeConstraint/Parameterizable.pm
@@ -192,7 +192,7 @@ sub parameterize {
                     constraining_value => $args,
                     parent_type_constraint=>$self->parent_type_constraint,
                     constraining_value_type_constraint => $self->constraining_value_type_constraint,
-                    message => $self->message,
+                    ($self->has_message ? (message => $self->message) : ()),
                 );
             }
         }

--- a/t/07-no-message.t
+++ b/t/07-no-message.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+{
+    package Test::MyMooseClass;
+
+    use Moose;
+    use MooseX::Types::Parameterizable qw(Parameterizable);
+    use MooseX::Types::Moose qw(Str Int);
+    use MooseX::Types -declare=>[qw(Varchar)];
+
+    ## Minor change from docs to avoid additional test dependencies
+    subtype Varchar,
+      as Parameterizable[Str,Int],
+      where {
+        my($string, $int) = @_;
+        $int >= length($string) ? 1:0;
+      };
+
+	has short_string => ( is => 'rw', isa => Varchar[5] );
+}
+
+my $obj = Test::MyMooseClass->new(short_string => 'four');
+
+is $obj->short_string, 'four', 'attribute stored correctly';
+
+# this should die
+eval { $obj->short_string('longer') };
+
+like $@, qr/Attribute \(short_string\) does not pass the type constraint/, 'fails on longer string with correct error message';
+
+done_testing;


### PR DESCRIPTION
Moose does not like receiving an undefined message param when declaring a type constraint
